### PR TITLE
feat: port provision instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 .vscode
 /kubeconfig
 __debug_bin
-testdata/
+testdata/bin/
+testdata/crds/*.yaml
+!testdata/crds/compositeinstances.syn.tools.yaml
 node_modules/
 e2e/debug/
 crossplane-service-broker
 !cmd/crossplane-service-broker
 cover.out
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,8 @@ $(TESTDATA_CRD_DIR): $(TESTDATA_DIR)
 $(TESTDATA_CRD_DIR)/%.yaml: | $(TESTDATA_CRD_DIR)
 	curl -sSLo $@ https://raw.githubusercontent.com/crossplane/crossplane/$(CROSSPLANE_VERSION)/cluster/charts/crossplane/crds/$*.yaml
 
-$(ENVTEST_ASSETS_DIR)/setup-envtest.sh: $(TESTDATA_DIR)
-	curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-
 .PHONY: integration_test
-integration_test: fmt vet $(ENVTEST_ASSETS_DIR)/setup-envtest.sh $(CROSSPLANE_CRDS)
+integration_test: fmt vet $(CROSSPLANE_CRDS)
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 
 .PHONY: setup_e2e_test

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pivotal-cf/brokerapi/v7 v7.5.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0
+	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.20.0
 	k8s.io/client-go v0.19.3
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920

--- a/go.sum
+++ b/go.sum
@@ -795,10 +795,12 @@ go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygL
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
@@ -806,6 +808,7 @@ go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15/go.mod h1:vwi/ZaCAaUcBkycHslx
 go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go.uber.org/zap v1.16.0 h1:uFRZXykJGK9lLY4HtgSw44DnIcAM+kRBP7x5m+NpAOM=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/internal/broker/domain.go
+++ b/internal/broker/domain.go
@@ -1,0 +1,89 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/pivotal-cf/brokerapi/v7/domain"
+	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v7/middlewares"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/pointer"
+
+	"github.com/vshn/crossplane-service-broker/internal/crossplane"
+)
+
+func newService(service *crossplane.ServiceXRD, plans []domain.ServicePlan, logger lager.Logger) domain.Service {
+	meta := &domain.ServiceMetadata{}
+	if err := json.Unmarshal([]byte(service.Metadata), meta); err != nil {
+		logger.Error("parse-metadata", err)
+		meta.DisplayName = service.Labels.ServiceName
+	}
+
+	var tags []string
+	if err := json.Unmarshal([]byte(service.Tags), &tags); err != nil {
+		logger.Error("parse-tags", err)
+	}
+
+	return domain.Service{
+		ID:                   service.Labels.ServiceID,
+		Name:                 service.Labels.ServiceName,
+		Description:          service.Description,
+		Bindable:             service.Labels.Bindable,
+		InstancesRetrievable: true,
+		BindingsRetrievable:  service.Labels.Bindable,
+		PlanUpdatable:        false,
+		Plans:                plans,
+		Metadata:             meta,
+		Tags:                 tags,
+	}
+}
+
+func newServicePlan(plan *crossplane.Plan, logger lager.Logger) domain.ServicePlan {
+	planName := plan.Labels.PlanName
+	meta := &domain.ServicePlanMetadata{}
+	if err := json.Unmarshal([]byte(plan.Metadata), meta); err != nil {
+		logger.Error("parse-metadata", err)
+		meta.DisplayName = planName
+	}
+	return domain.ServicePlan{
+		ID:          plan.Composition.Name,
+		Name:        planName,
+		Description: plan.Description,
+		Free:        pointer.BoolPtr(false),
+		Bindable:    &plan.Labels.Bindable,
+		Metadata:    meta,
+	}
+}
+
+// toApiResponseError converts an error to a proper API error
+func toApiResponseError(ctx context.Context, err error) *apiresponses.FailureResponse {
+	id, ok := ctx.Value(middlewares.CorrelationIDKey).(string)
+	if !ok {
+		id = "unknown"
+	}
+
+	var kErr *k8serrors.StatusError
+	if errors.As(err, &kErr) {
+		err = apiresponses.NewFailureResponseBuilder(
+			kErr,
+			int(kErr.ErrStatus.Code),
+			"invalid",
+		).WithErrorKey(string(kErr.ErrStatus.Reason)).Build()
+	}
+
+	var apiErr *apiresponses.FailureResponse
+	if errors.As(err, &apiErr) {
+		return apiErr.AppendErrorMessage(fmt.Sprintf("(correlation-id: %q)", id))
+	}
+
+	return apiresponses.NewFailureResponseBuilder(
+		fmt.Errorf("%w (correlation-id: %q)", err, id),
+		http.StatusInternalServerError,
+		"internal-server-error",
+	).Build()
+}

--- a/internal/crossplane/client.go
+++ b/internal/crossplane/client.go
@@ -2,20 +2,40 @@ package crossplane
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"sort"
 
 	"code.cloudfoundry.org/lager"
 	helm "github.com/crossplane-contrib/provider-helm/apis"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	crossplane "github.com/crossplane/crossplane/apis"
-	xv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	xv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ErrInstanceNotFound is an instance doesn't exist
+var ErrInstanceNotFound = errors.New("instance not found")
+
+const (
+	// instanceSpecParamsPath is the path to an instance's parameters
+	instanceSpecParamsPath = "spec.parameters"
+
+	// instanceParamsParentReferenceName is the name of an instance's parent reference parameter
+	instanceParamsParentReferenceName = "parent_reference"
+	// instanceSpecParamsParentReferencePath is the path to an instance's parent reference parameter
+	instanceSpecParamsParentReferencePath = instanceSpecParamsPath + "." + instanceParamsParentReferenceName
 )
 
 // Crossplane client to access crossplane resources.
@@ -26,8 +46,8 @@ type Crossplane struct {
 	serviceIDs []string
 }
 
-// setupScheme configures the given runtime.Scheme with all required resources
-func setupScheme(scheme *runtime.Scheme) error {
+// Register configures the given runtime.Scheme with all required resources
+func Register(scheme *runtime.Scheme) error {
 	sBuilder := runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
 		metav1.AddToGroupVersion(s, schema.GroupVersion{Group: "syn.tools", Version: "v1alpha1"})
 		return nil
@@ -48,7 +68,7 @@ func setupScheme(scheme *runtime.Scheme) error {
 // New instantiates a crossplane client.
 func New(serviceIDs []string, config *rest.Config, logger lager.Logger) (*Crossplane, error) {
 	scheme := runtime.NewScheme()
-	if err := setupScheme(scheme); err != nil {
+	if err := Register(scheme); err != nil {
 		return nil, err
 	}
 
@@ -70,15 +90,16 @@ func New(serviceIDs []string, config *rest.Config, logger lager.Logger) (*Crossp
 }
 
 type ServiceXRD struct {
-	XRD         xv1.CompositeResourceDefinition
+	XRD         xv1beta1.CompositeResourceDefinition
 	Labels      *Labels
 	Metadata    string
 	Tags        string
 	Description string
 }
 
-func (cp *Crossplane) ServiceXRDs(ctx context.Context) ([]ServiceXRD, error) {
-	xrds := &xv1.CompositeResourceDefinitionList{}
+// ServiceXRDs retrieves all defined services (defined by XRDs with the ServiceIDLabel) on the cluster.
+func (cp Crossplane) ServiceXRDs(ctx context.Context) ([]*ServiceXRD, error) {
+	xrds := &xv1beta1.CompositeResourceDefinitionList{}
 
 	req, err := labels.NewRequirement(ServiceIDLabel, selection.In, cp.serviceIDs)
 	if err != nil {
@@ -92,13 +113,13 @@ func (cp *Crossplane) ServiceXRDs(ctx context.Context) ([]ServiceXRD, error) {
 		return nil, err
 	}
 
-	sxrds := make([]ServiceXRD, len(xrds.Items))
+	sxrds := make([]*ServiceXRD, len(xrds.Items))
 	for i, xrd := range xrds.Items {
 		l, err := parseLabels(xrd.Labels)
 		if err != nil {
 			return nil, err
 		}
-		sxrds[i] = ServiceXRD{
+		sxrds[i] = &ServiceXRD{
 			XRD:         xrd,
 			Labels:      l,
 			Metadata:    xrd.Annotations[MetadataAnnotation],
@@ -110,21 +131,15 @@ func (cp *Crossplane) ServiceXRDs(ctx context.Context) ([]ServiceXRD, error) {
 	return sxrds, nil
 }
 
-type Plan struct {
-	Composition xv1.Composition
-	Labels      *Labels
-	Metadata    string
-	Tags        string
-	Description string
-}
-
-func (cp *Crossplane) Plans(ctx context.Context, serviceIDs []string) ([]Plan, error) {
+// Plans retrieves all plans per passed service. Plans are deployed Compositions with the ServiceIDLabel
+// assigned. The plans are ordered by name.
+func (cp Crossplane) Plans(ctx context.Context, serviceIDs []string) ([]*Plan, error) {
 	req, err := labels.NewRequirement(ServiceIDLabel, selection.In, serviceIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	compositions := &xv1.CompositionList{}
+	compositions := &xv1beta1.CompositionList{}
 	err = cp.client.List(ctx, compositions, client.MatchingLabelsSelector{
 		Selector: labels.NewSelector().Add(*req),
 	})
@@ -132,20 +147,100 @@ func (cp *Crossplane) Plans(ctx context.Context, serviceIDs []string) ([]Plan, e
 		return compositions.Items[i].Labels[PlanNameLabel] < compositions.Items[j].Labels[PlanNameLabel]
 	})
 
-	plans := make([]Plan, len(compositions.Items))
+	plans := make([]*Plan, len(compositions.Items))
 	for i, c := range compositions.Items {
-		l, err := parseLabels(c.Labels)
+		p, err := newPlan(&c)
 		if err != nil {
 			return nil, err
 		}
-		plans[i] = Plan{
-			Composition: c,
-			Labels:      l,
-			Metadata:    c.Annotations[MetadataAnnotation],
-			Tags:        c.Annotations[TagsAnnotation],
-			Description: c.Annotations[DescriptionAnnotation],
-		}
+		plans[i] = p
 	}
 
 	return plans, nil
+}
+
+// Plan retrieves a single plan as deployed using a Composition. The planID corresponds to the
+// Compositions name.
+func (cp Crossplane) Plan(ctx context.Context, planID string) (*Plan, error) {
+	composition := &xv1beta1.Composition{}
+	err := cp.client.Get(ctx, types.NamespacedName{Name: planID}, composition)
+	if err != nil {
+		return nil, err
+	}
+	return newPlan(composition)
+}
+
+// Instances retrieves an instance based on the given instanceID and plan. Besides the instanceID, the planName
+// has to match.
+// The `ok` parameter is *only* set to true if no error is returned and the instance already exists.
+// Normal errors are returned as-is.
+// FIXME(mw): is it correct to return `false, ErrInstanceNotFound` if PlanNameLabel does not match? And how should that be handled?
+//            Ported from PoC code as-is, and ErrInstanceNotFound is handled as instance really not found, however as the ID exists, how
+//            can we speak about having no instance with that name? It's a UUID after all.
+func (cp Crossplane) Instance(ctx context.Context, id string, plan *Plan) (inst *Instance, ok bool, err error) {
+	gvk, err := plan.GVK()
+
+	cmp := composite.New(composite.WithGroupVersionKind(gvk))
+	cmp.SetName(id)
+
+	err = cp.client.Get(ctx, types.NamespacedName{
+		Name: id,
+	}, cmp)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	inst, err = newInstance(cmp)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if inst.Labels.PlanName != plan.Labels.PlanName {
+		// TODO(mw): should we log here? PoC code logs.
+		return nil, false, ErrInstanceNotFound
+	}
+
+	return inst, true, nil
+}
+
+// CreateInstance sets a new composite with assigned plan and params up.
+// TODO(mw): simplify, refactor
+func (cp Crossplane) CreateInstance(ctx context.Context, id string, plan *Plan, params json.RawMessage) error {
+	l := map[string]string{
+		InstanceIDLabel: id,
+	}
+	// Copy relevant labels from plan
+	for _, name := range []string{ServiceIDLabel, ServiceNameLabel, PlanNameLabel, ClusterLabel, SLALabel} {
+		l[name] = plan.Composition.Labels[name]
+	}
+
+	gvk, err := plan.GVK()
+	if err != nil {
+		return err
+	}
+
+	cmp := composite.New(composite.WithGroupVersionKind(gvk))
+	cmp.SetName(id)
+	cmp.SetCompositionReference(&corev1.ObjectReference{
+		Name: plan.Labels.PlanName,
+	})
+	paramMap := map[string]interface{}{}
+	if params != nil {
+		if err := json.Unmarshal(params, &paramMap); err != nil {
+			return err
+		}
+		if parentReference, err := fieldpath.Pave(paramMap).GetString(instanceParamsParentReferenceName); err == nil {
+			// Set parent reference in a label so we can search for it later.
+			l[ParentIDLabel] = parentReference
+		}
+	}
+	if err := fieldpath.Pave(cmp.Object).SetValue(instanceSpecParamsPath, paramMap); err != nil {
+		return err
+	}
+	cmp.SetLabels(l)
+	cp.logger.Debug("create-instance", lager.Data{"instance": cmp})
+	return cp.client.Create(ctx, cmp)
 }

--- a/internal/crossplane/metadata.go
+++ b/internal/crossplane/metadata.go
@@ -23,6 +23,10 @@ const (
 	ServiceIDLabel = SynToolsBase + "/id"
 	// PlanNameLabel of the instance
 	PlanNameLabel = SynToolsBase + "/plan"
+	// ClusterLabel name of the cluster this instance is deployed to
+	ClusterLabel = SynToolsBase + "/cluster"
+	// SLALabel SLA level for this instance
+	SLALabel = SynToolsBase + "/sla"
 	// InstanceIDLabel of the instance
 	InstanceIDLabel = SynToolsBase + "/instance"
 	// ParentIDLabel of the instance

--- a/internal/crossplane/types.go
+++ b/internal/crossplane/types.go
@@ -1,0 +1,53 @@
+package crossplane
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
+	xv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Plan struct {
+	Composition *xv1beta1.Composition
+	Labels      *Labels
+	Metadata    string
+	Tags        string
+	Description string
+}
+
+func (p Plan) GVK() (schema.GroupVersionKind, error) {
+	groupVersion, err := schema.ParseGroupVersion(p.Composition.Spec.CompositeTypeRef.APIVersion)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	return groupVersion.WithKind(p.Composition.Spec.CompositeTypeRef.Kind), nil
+}
+
+func newPlan(c *xv1beta1.Composition) (*Plan, error) {
+	l, err := parseLabels(c.Labels)
+	if err != nil {
+		return nil, err
+	}
+	return &Plan{
+		Composition: c,
+		Labels:      l,
+		Metadata:    c.Annotations[MetadataAnnotation],
+		Tags:        c.Annotations[TagsAnnotation],
+		Description: c.Annotations[DescriptionAnnotation],
+	}, nil
+}
+
+type Instance struct {
+	Composition *composite.Unstructured
+	Labels      *Labels
+}
+
+func newInstance(c *composite.Unstructured) (*Instance, error) {
+	l, err := parseLabels(c.GetLabels())
+	if err != nil {
+		return nil, err
+	}
+	return &Instance{
+		Composition: c,
+		Labels:      l,
+	}, nil
+}

--- a/pkg/brokerapi/brokerapi_test.go
+++ b/pkg/brokerapi/brokerapi_test.go
@@ -4,17 +4,23 @@ package brokerapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composite"
 	"github.com/crossplane/crossplane-runtime/pkg/test/integration"
 	xv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	xv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	"github.com/go-logr/zapr"
 	"github.com/pivotal-cf/brokerapi/v7/domain"
+	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v7/middlewares"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +29,8 @@ import (
 	"github.com/vshn/crossplane-service-broker/internal/broker"
 	"github.com/vshn/crossplane-service-broker/internal/crossplane"
 )
+
+type preRunFunc func(c client.Client) error
 
 func TestBrokerAPI_Services(t *testing.T) {
 	type fields struct {
@@ -35,61 +43,15 @@ func TestBrokerAPI_Services(t *testing.T) {
 		ctx      context.Context
 		want     []domain.Service
 		wantErr  bool
-		preRunFn func(c client.Client) error
+		preRunFn preRunFunc
 	}{
 		{
 			name: "returns the catalog successfully",
 			ctx:  context.TODO(),
-			preRunFn: func(c client.Client) error {
-				ctx := context.TODO()
-				objs := []runtime.Object{
-					&xv1.CompositeResourceDefinition{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "testservice",
-							Labels: map[string]string{
-								crossplane.ServiceIDLabel:   "1",
-								crossplane.ServiceNameLabel: "testservice",
-								crossplane.BindableLabel:    "true",
-							},
-							Annotations: map[string]string{
-								crossplane.DescriptionAnnotation: "testservice description",
-								crossplane.MetadataAnnotation:    `{"displayName": "testservice"}`,
-								crossplane.TagsAnnotation:        `["foo","bar","baz"]`,
-							},
-						},
-						Spec: xv1.CompositeResourceDefinitionSpec{
-							Versions: []xv1.CompositeResourceDefinitionVersion{
-								{
-									Name: "v1",
-								},
-							},
-						},
-					},
-					&xv1.Composition{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "testservice-small",
-							Labels: map[string]string{
-								crossplane.ServiceIDLabel: "1",
-								crossplane.PlanNameLabel:  "small",
-								crossplane.BindableLabel:  "true",
-							},
-							Annotations: map[string]string{
-								crossplane.DescriptionAnnotation: "testservice-small plan description",
-								crossplane.MetadataAnnotation:    `{"displayName": "small"}`,
-							},
-						},
-						Spec: xv1.CompositionSpec{
-							Resources: []xv1.ComposedTemplate{},
-						},
-					},
-				}
-				for _, obj := range objs {
-					if err := c.Create(ctx, obj); err != nil {
-						return err
-					}
-				}
-				return nil
-			},
+			preRunFn: createObjects(context.TODO(), []runtime.Object{
+				newService("1"),
+				newServicePlan("1", "1-1").Composition,
+			}),
 			want: []domain.Service{
 				{
 					ID:                   "1",
@@ -101,11 +63,11 @@ func TestBrokerAPI_Services(t *testing.T) {
 					PlanUpdatable:        false,
 					Plans: []domain.ServicePlan{
 						{
-							ID:          "testservice-small",
+							ID:          "1-1",
 							Name:        "small",
 							Description: "testservice-small plan description",
 							Free:        boolPtr(false),
-							Bindable:    boolPtr(true),
+							Bindable:    boolPtr(false),
 							Metadata: &domain.ServicePlanMetadata{
 								DisplayName: "small",
 							},
@@ -120,36 +82,14 @@ func TestBrokerAPI_Services(t *testing.T) {
 		},
 	}
 
-	if db := os.Getenv("DEBUG"); db != "" {
-		zl, _ := zap.NewDevelopment()
-		log.SetLogger(zapr.NewLogger(zl))
-	}
-
-	m, err := integration.New(nil,
-		integration.WithCRDPaths("../../testdata/crds"),
-	)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("unable to setup integration test manager: %s", err))
-		return
-	}
-
-	m.Run()
-
-	scheme := m.GetScheme()
-	assert.NoError(t, xv1.AddToScheme(scheme))
-
-	logger := lager.NewLogger("test")
-
-	cp, err := crossplane.New([]string{"1", "2"}, m.GetConfig(), logger)
-	if err != nil {
-		assert.FailNow(t, fmt.Sprintf("unable to setup crossplane client: %s", err))
-		return
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			m, logger, cp, err := setupManager(t)
+			if err != nil {
+				assert.FailNow(t, fmt.Sprintf("unable to setup integration test manager: %s", err))
+				return
+			}
 			defer m.Cleanup()
-
 			assert.NoError(t, tt.preRunFn(m.GetClient()))
 
 			b := broker.New(cp, logger)
@@ -165,8 +105,249 @@ func TestBrokerAPI_Services(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got)
+
 		})
 	}
+}
+
+func TestBrokerAPI_Provision(t *testing.T) {
+	type fields struct {
+		broker *broker.Broker
+		logger lager.Logger
+	}
+	type args struct {
+		ctx          context.Context
+		instanceID   string
+		details      domain.ProvisionDetails
+		asyncAllowed bool
+	}
+	ctx := context.WithValue(context.TODO(), middlewares.CorrelationIDKey, "corrid")
+
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     *domain.ProvisionedServiceSpec
+		wantErr  error
+		preRunFn preRunFunc
+	}{
+		{
+			name: "requires async",
+			args: args{
+				ctx:          ctx,
+				instanceID:   "1",
+				details:      domain.ProvisionDetails{},
+				asyncAllowed: false,
+			},
+			preRunFn: func(c client.Client) error {
+				return nil
+			},
+			want:    nil,
+			wantErr: apiresponses.ErrAsyncRequired,
+		},
+		{
+			name: "specified plan must exist",
+			args: args{
+				ctx:        ctx,
+				instanceID: "1",
+				details: domain.ProvisionDetails{
+					PlanID: "1-1",
+				},
+				asyncAllowed: true,
+			},
+			preRunFn: func(c client.Client) error {
+				return nil
+			},
+			want:    nil,
+			wantErr: errors.New(`compositions.apiextensions.crossplane.io "1-1" not found (correlation-id: "corrid")`),
+		},
+		{
+			name: "creates an instance",
+			args: args{
+				ctx:        ctx,
+				instanceID: "1",
+				details: domain.ProvisionDetails{
+					PlanID:    "1-1",
+					ServiceID: "1",
+				},
+				asyncAllowed: true,
+			},
+			preRunFn: createObjects(context.TODO(), []runtime.Object{
+				newService("1"),
+				newServicePlan("1", "1-1").Composition,
+			}),
+			want:    &domain.ProvisionedServiceSpec{IsAsync: true},
+			wantErr: nil,
+		},
+		{
+			name: "returns already exists if instance already exists",
+			args: args{
+				ctx:        ctx,
+				instanceID: "1",
+				details: domain.ProvisionDetails{
+					PlanID:    "1-1",
+					ServiceID: "1",
+				},
+				asyncAllowed: true,
+			},
+			preRunFn: func(c client.Client) error {
+				service := newService("1")
+				servicePlan := newServicePlan("1", "1-1")
+
+				return createObjects(context.TODO(), []runtime.Object{
+					service,
+					servicePlan.Composition,
+					newInstance("1", servicePlan),
+				})(c)
+			},
+			want:    &domain.ProvisionedServiceSpec{AlreadyExists: true},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, logger, cp, err := setupManager(t)
+			if err != nil {
+				assert.FailNow(t, fmt.Sprintf("unable to setup integration test manager: %s", err))
+				return
+			}
+			defer m.Cleanup()
+			assert.NoError(t, tt.preRunFn(m.GetClient()))
+
+			b := broker.New(cp, logger)
+
+			bAPI := BrokerAPI{
+				broker: b,
+				logger: logger,
+			}
+			got, err := bAPI.Provision(tt.args.ctx, tt.args.instanceID, tt.args.details, tt.args.asyncAllowed)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, *tt.want, got)
+		})
+	}
+}
+
+func newService(serviceID string) *xv1.CompositeResourceDefinition {
+	return &xv1.CompositeResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "syn.tools/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testservice",
+			Labels: map[string]string{
+				crossplane.ServiceIDLabel:   serviceID,
+				crossplane.ServiceNameLabel: "testservice",
+				crossplane.BindableLabel:    "true",
+			},
+			Annotations: map[string]string{
+				crossplane.DescriptionAnnotation: "testservice description",
+				crossplane.MetadataAnnotation:    `{"displayName": "testservice"}`,
+				crossplane.TagsAnnotation:        `["foo","bar","baz"]`,
+			},
+		},
+		Spec: xv1.CompositeResourceDefinitionSpec{
+			Versions: []xv1.CompositeResourceDefinitionVersion{
+				{
+					Name: "v1",
+				},
+			},
+		},
+	}
+}
+
+func newServicePlan(serviceID string, planID string) *crossplane.Plan {
+	name := "small"
+	return &crossplane.Plan{
+		Labels: &crossplane.Labels{
+			PlanName: name,
+		},
+		Composition: &xv1beta1.Composition{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "servicePlan",
+				APIVersion: "syn.tools/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: planID,
+				Labels: map[string]string{
+					crossplane.ServiceIDLabel:   serviceID,
+					crossplane.ServiceNameLabel: "testservice",
+					crossplane.PlanNameLabel:    name,
+					crossplane.BindableLabel:    "false",
+				},
+				Annotations: map[string]string{
+					crossplane.DescriptionAnnotation: "testservice-small plan description",
+					crossplane.MetadataAnnotation:    `{"displayName": "small"}`,
+				},
+			},
+			Spec: xv1beta1.CompositionSpec{
+				Resources: []xv1beta1.ComposedTemplate{},
+				CompositeTypeRef: xv1beta1.TypeReference{
+					APIVersion: "syn.tools/v1alpha1",
+					Kind:       "CompositeInstance",
+				},
+			},
+		},
+	}
+}
+
+func newInstance(instanceID string, plan *crossplane.Plan) *composite.Unstructured {
+	gvk, _ := plan.GVK()
+	cmp := composite.New(composite.WithGroupVersionKind(gvk))
+	cmp.SetName(instanceID)
+	cmp.SetCompositionReference(&corev1.ObjectReference{
+		Name: plan.Labels.PlanName,
+	})
+	cmp.SetLabels(map[string]string{
+		crossplane.PlanNameLabel: plan.Labels.PlanName,
+	})
+	return cmp
+}
+
+func createObjects(ctx context.Context, objs []runtime.Object) preRunFunc {
+	return func(c client.Client) error {
+		for _, obj := range objs {
+			if err := c.Create(ctx, obj); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func setupManager(t *testing.T) (*integration.Manager, lager.Logger, *crossplane.Crossplane, error) {
+	if db := os.Getenv("DEBUG"); db != "" {
+		zl, _ := zap.NewDevelopment()
+		log.SetLogger(zapr.NewLogger(zl))
+	}
+
+	m, err := integration.New(nil,
+		integration.WithCRDPaths("../../testdata/crds"),
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	m.Run()
+
+	scheme := m.GetScheme()
+	assert.NoError(t, xv1.AddToScheme(scheme))
+	assert.NoError(t, xv1beta1.AddToScheme(scheme))
+	assert.NoError(t, crossplane.Register(scheme))
+
+	logger := lager.NewLogger("test")
+
+	cp, err := crossplane.New([]string{"1", "2"}, m.GetConfig(), logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return m, logger, cp, nil
 }
 
 func boolPtr(b bool) *bool {

--- a/testdata/crds/compositeinstances.syn.tools.yaml
+++ b/testdata/crds/compositeinstances.syn.tools.yaml
@@ -1,0 +1,147 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    name: compositeinstances.syn.tools
+  name: compositeinstances.syn.tools
+  ownerReferences:
+    - apiVersion: apiextensions.crossplane.io/v1beta1
+      controller: true
+      kind: CompositeResourceDefinition
+      name: compositeinstances.syn.tools
+      uid: 3ec404a6-f02e-4098-98c6-b4c5c1f8a20e
+spec:
+  conversion:
+    strategy: None
+  group: syn.tools
+  names:
+    categories:
+      - composite
+    kind: CompositeInstance
+    listKind: CompositeInstanceList
+    plural: compositeinstances
+    singular: compositeinstance
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .metadata.labels['service\.syn\.tools/plan']
+          name: Plan
+          type: string
+        - jsonPath: .metadata.labels['service\.syn\.tools/cluster']
+          name: Cluster
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: READY
+          type: string
+        - jsonPath: .spec.compositionRef.name
+          name: COMPOSITION
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                claimRef:
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - apiVersion
+                    - kind
+                    - namespace
+                    - name
+                  type: object
+                compositionRef:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                compositionSelector:
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  required:
+                    - matchLabels
+                  type: object
+                resourceRefs:
+                  items:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      uid:
+                        type: string
+                    required:
+                      - apiVersion
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                writeConnectionSecretToRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                    - namespace
+                  type: object
+              type: object
+            status:
+              properties:
+                conditions:
+                  description: Conditions of the resource.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                connectionDetails:
+                  properties:
+                    lastPublishedTime:
+                      format: date-time
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/testdata/setup-envtest.sh
+++ b/testdata/setup-envtest.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+#  Copyright 2020 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+function setup_envtest_env {
+  header_text "setting up env vars"
+
+  # Setup env vars
+  KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS:-""}
+  if [[ -z "${KUBEBUILDER_ASSETS}" ]]; then
+    export KUBEBUILDER_ASSETS=$1/bin
+  fi
+}
+
+# fetch k8s API gen tools and make it available under envtest_root_dir/bin.
+#
+# Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
+# in your environment to any value:
+#
+# $ SKIP_FETCH_TOOLS=1 ./check-everything.sh
+#
+# If you skip fetching tools, this script will use the tools already on your
+# machine.
+function fetch_envtest_tools {
+  SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
+  if [ -n "$SKIP_FETCH_TOOLS" ]; then
+    return 0
+  fi
+
+  tmp_root=/tmp
+  envtest_root_dir=$tmp_root/envtest
+
+  k8s_version="${ENVTEST_K8S_VERSION:-1.19.2}"
+  goarch="$(go env GOARCH)"
+  goos="$(go env GOOS)"
+
+  if [[ "$goos" != "linux" && "$goos" != "darwin" ]]; then
+    echo "OS '$goos' not supported. Aborting." >&2
+    return 1
+  fi
+
+  local dest_dir="${1}"
+
+  # use the pre-existing version in the temporary folder if it matches our k8s version
+  if [[ -x "${dest_dir}/bin/kube-apiserver" ]]; then
+    version=$("${dest_dir}"/bin/kube-apiserver --version)
+    if [[ $version == *"${k8s_version}"* ]]; then
+      header_text "Using cached envtest tools from ${dest_dir}"
+      return 0
+    fi
+  fi
+
+  header_text "fetching envtest tools@${k8s_version} (into '${dest_dir}')"
+  envtest_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
+  envtest_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$envtest_tools_archive_name"
+
+  envtest_tools_archive_path="$tmp_root/$envtest_tools_archive_name"
+  if [ ! -f $envtest_tools_archive_path ]; then
+    curl -sL ${envtest_tools_download_url} -o "$envtest_tools_archive_path"
+  fi
+
+  mkdir -p "${dest_dir}"
+  tar -C "${dest_dir}" --strip-components=1 -zvxf "$envtest_tools_archive_path"
+}


### PR DESCRIPTION
## TODO
- [x] check why toApiResponseError panics on `eden catalog`
- [x] check why `eden catalog` returns no kind found
- [x] test `eden provision` against redis & mariadb
- [x] create unit & integration tests