### PR TITLE
refactor: context/log passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ $(TESTDATA_CRD_DIR)/%.yaml:
 	curl -sSLo $@ https://raw.githubusercontent.com/crossplane/crossplane/$(CROSSPLANE_VERSION)/cluster/charts/crossplane/crds/$*.yaml
 
 .PHONY: integration_test
-integration_test: fmt vet $(CROSSPLANE_CRDS)
+integration_test: $(CROSSPLANE_CRDS)
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 
 .PHONY: setup_e2e_test

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -15,8 +15,6 @@ import (
 )
 
 var (
-	// ErrInstanceNotFound is an instance doesn't exist
-	ErrInstanceNotFound = errors.New("instance not found")
 	// ErrServiceUpdateNotPermitted when updating an instance
 	ErrServiceUpdateNotPermitted = errors.New("service update not permitted")
 	// ErrPlanChangeNotPermitted when updating an instance's plan (only premium<->standard is permitted)

--- a/internal/crossplane/service_mariadb.go
+++ b/internal/crossplane/service_mariadb.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/lager"
+	xrv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -92,5 +93,15 @@ func (msb MariadbServiceBinder) GetBinding(_ context.Context, _ string) (Credent
 
 // FIXME(mw): FinishProvision might be needed, but probably not.
 func (msb MariadbServiceBinder) FinishProvision(ctx context.Context) error {
+	s, err := msb.cp.getCredentials(ctx, msb.instanceID)
+	if err != nil {
+		return err
+	}
+
+	// having an endpoint in the secret means fetching the endpoint via HaProxy
+	// has been successfully implemented using provider-helm.
+	if s.Data[xrv1.ResourceCredentialsSecretEndpointKey] != nil {
+		return nil
+	}
 	return errors.New("FinishProvision deactivated until proper solution in place. Retrieving Endpoint needs implementation.")
 }

--- a/internal/crossplane/service_mariadb_database.go
+++ b/internal/crossplane/service_mariadb_database.go
@@ -175,7 +175,7 @@ func (msb MariadbDatabaseServiceBinder) createBinding(ctx context.Context, bindi
 		return "", err
 	}
 
-	msb.cp.logger.Debug("create-binding", lager.Data{"instance": cmp})
+	msb.logger.Debug("create-binding", lager.Data{"instance": cmp})
 	err = msb.cp.client.Create(ctx, cmp)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return "", err

--- a/pkg/brokerapi/brokerapi.go
+++ b/pkg/brokerapi/brokerapi.go
@@ -104,8 +104,6 @@ func (b BrokerAPI) Update(ctx context.Context, instanceID string, details domain
 		switch err {
 		case broker.ErrPlanChangeNotPermitted, broker.ErrServiceUpdateNotPermitted:
 			err = apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, "update-instance-failed")
-		case broker.ErrInstanceNotFound:
-			err = apiresponses.ErrInstanceDoesNotExist
 		}
 		return res, toApiResponseError(rctx, err)
 	}

--- a/pkg/brokerapi/brokerapi_test.go
+++ b/pkg/brokerapi/brokerapi_test.go
@@ -110,7 +110,7 @@ func TestBrokerAPI_Services(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -273,7 +273,7 @@ func TestBrokerAPI_Provision(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -411,7 +411,7 @@ func TestBrokerAPI_Deprovision(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -583,7 +583,7 @@ func TestBrokerAPI_LastOperation(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -729,7 +729,7 @@ func TestBrokerAPI_Bind(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -833,7 +833,7 @@ func TestBrokerAPI_GetBinding(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -940,7 +940,7 @@ func TestBrokerAPI_GetInstance(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -1170,7 +1170,7 @@ func TestBrokerAPI_Update(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -1284,7 +1284,7 @@ func TestBrokerAPI_Unbind(t *testing.T) {
 			defer m.Cleanup()
 			require.NoError(t, tt.preRunFn(m.GetClient()))
 
-			b := broker.New(cp, logger)
+			b := broker.New(cp)
 
 			bAPI := BrokerAPI{
 				broker: b,
@@ -1549,7 +1549,7 @@ func setupManager(t *testing.T) (*integration.Manager, lager.Logger, *crossplane
 
 	logger := lager.NewLogger("test")
 
-	cp, err := crossplane.New([]string{"1", "2"}, testNamespace, m.GetConfig(), logger)
+	cp, err := crossplane.New([]string{"1", "2"}, testNamespace, m.GetConfig())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/reqcontext/reqcontext.go
+++ b/pkg/reqcontext/reqcontext.go
@@ -1,0 +1,34 @@
+package reqcontext
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/pivotal-cf/brokerapi/v7/middlewares"
+)
+
+// ReqContext provides a simple struct to contain required request scoped context. In doing so we avoid
+// stuffing everything into `req.Context()` which contains just untyped values.
+// See e.g. https://dave.cheney.net/2017/01/26/context-is-for-cancelation why this would be a bad idea.
+type ReqContext struct {
+	Context       context.Context
+	CorrelationID string
+	Logger        lager.Logger
+}
+
+func NewReqContext(ctx context.Context, logger lager.Logger, logData lager.Data) *ReqContext {
+	if logData == nil {
+		logData = lager.Data{}
+	}
+	id, ok := ctx.Value(middlewares.CorrelationIDKey).(string)
+	if !ok {
+		id = "unknown"
+	}
+	logData["correlation-id"] = id
+
+	return &ReqContext{
+		Context:       ctx,
+		CorrelationID: id,
+		Logger:        logger.WithData(logData),
+	}
+}


### PR DESCRIPTION
this changes context & log passing to use a custom `ReqContext`
structure containing the request-scoped logger and the request context.

This change enables us to log everywhere with the correlation-id added.


based on #15 - will rebase once done