### PR TITLE
fix: plans iterator loop pointer pitfall

### DIFF
--- a/internal/crossplane/client.go
+++ b/internal/crossplane/client.go
@@ -143,7 +143,7 @@ func (cp Crossplane) Plans(ctx context.Context, serviceIDs []string) ([]*Plan, e
 
 	plans := make([]*Plan, len(compositions.Items))
 	for i, c := range compositions.Items {
-		p, err := newPlan(&c)
+		p, err := newPlan(c)
 		if err != nil {
 			return nil, err
 		}
@@ -156,8 +156,8 @@ func (cp Crossplane) Plans(ctx context.Context, serviceIDs []string) ([]*Plan, e
 // Plan retrieves a single plan as deployed using a Composition. The planID corresponds to the
 // Compositions name.
 func (cp Crossplane) Plan(ctx context.Context, planID string) (*Plan, error) {
-	composition := &xv1.Composition{}
-	err := cp.client.Get(ctx, types.NamespacedName{Name: planID}, composition)
+	composition := xv1.Composition{}
+	err := cp.client.Get(ctx, types.NamespacedName{Name: planID}, &composition)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crossplane/types.go
+++ b/internal/crossplane/types.go
@@ -25,13 +25,13 @@ func (p Plan) GVK() (schema.GroupVersionKind, error) {
 	return groupVersion.WithKind(p.Composition.Spec.CompositeTypeRef.Kind), nil
 }
 
-func newPlan(c *xv1.Composition) (*Plan, error) {
+func newPlan(c xv1.Composition) (*Plan, error) {
 	l, err := parseLabels(c.Labels)
 	if err != nil {
 		return nil, err
 	}
 	return &Plan{
-		Composition: c,
+		Composition: &c,
 		Labels:      l,
 		Metadata:    c.Annotations[MetadataAnnotation],
 		Tags:        c.Annotations[TagsAnnotation],

--- a/pkg/brokerapi/brokerapi_test.go
+++ b/pkg/brokerapi/brokerapi_test.go
@@ -59,6 +59,7 @@ func TestBrokerAPI_Services(t *testing.T) {
 			preRunFn: createObjects(context.TODO(), []runtime.Object{
 				newService("1", crossplane.RedisService),
 				newServicePlan("1", "1-1", crossplane.RedisService).Composition,
+				newServicePlan("1", "1-2", crossplane.RedisService).Composition,
 			}),
 			want: []domain.Service{
 				{
@@ -73,6 +74,16 @@ func TestBrokerAPI_Services(t *testing.T) {
 						{
 							ID:          "1-1",
 							Name:        "small1-1",
+							Description: "testservice-small plan description",
+							Free:        boolPtr(false),
+							Bindable:    boolPtr(false),
+							Metadata: &domain.ServicePlanMetadata{
+								DisplayName: "small",
+							},
+						},
+						{
+							ID:          "1-2",
+							Name:        "small1-2",
 							Description: "testservice-small plan description",
 							Free:        boolPtr(false),
 							Bindable:    boolPtr(false),
@@ -882,7 +893,7 @@ func TestBrokerAPI_GetInstance(t *testing.T) {
 				})(c)
 			},
 			want: &domain.GetInstanceDetailsSpec{
-				PlanID:     "1-2",
+				PlanID:     "1-1",
 				ServiceID:  "1",
 				Parameters: nil,
 			},
@@ -910,7 +921,7 @@ func TestBrokerAPI_GetInstance(t *testing.T) {
 				})(c)
 			},
 			want: &domain.GetInstanceDetailsSpec{
-				PlanID:    "1-2",
+				PlanID:    "1-1",
 				ServiceID: "1",
 				Parameters: map[string]interface{}{
 					"parent_reference": "1",


### PR DESCRIPTION
taking a pointer of the iterator value yields in the same value always
taken for the whole resulting constructed slice.
