### PR TITLE
Methods to easily access Authorization information

### DIFF
--- a/cmd/crossplane-service-broker/main.go
+++ b/cmd/crossplane-service-broker/main.go
@@ -64,7 +64,7 @@ func run(signalChan chan os.Signal, logger lager.Logger) error {
 
 	router := mux.NewRouter()
 
-	cp, err := crossplane.New(cfg.ServiceIDs, cfg.Namespace, rConfig)
+	cp, err := crossplane.New(cfg, rConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/crossplane-service-broker/main.go
+++ b/cmd/crossplane-service-broker/main.go
@@ -72,8 +72,7 @@ func run(signalChan chan os.Signal, logger lager.Logger) error {
 	b := brokerapi.New(cp, logger.WithData(lager.Data{"component": "brokerapi"}))
 
 	serviceBrokerCredential := auth.SingleCredential(cfg.Username, cfg.Password)
-	jwtKeys := &cfg.JWKeyRegister
-	a := api.New(b, serviceBrokerCredential, jwtKeys, logger.WithData(lager.Data{"component": "api"}))
+	a := api.New(b, serviceBrokerCredential, &cfg.JWKeyRegister, logger.WithData(lager.Data{"component": "api"}))
 	router.NewRoute().Handler(a)
 
 	srv := http.Server{

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -14,30 +14,36 @@ NOTE: The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOUL
 |`~/.kube/config`
 |`/etc/osb/kubeconfig`
 
+|`OSB_NAMESPACE`
+|Which namespace the service broker shall use to create the resources.
+|_MUST be provided, no default_
+|`crossplane-service-broker`
+
 |`OSB_SERVICE_IDS`
 |Comma-separated list (no whitespace after comma!) of service ids available in your cluster.
 |_MUST be provided, no default value is defined._
 |`d7bb595e-abb4-49a6-97b3-a52c67150a34,5ba16ba2-7f07-4412-8fd2-0e9ac7acc831`
 
 |`OSB_USERNAME`
-|Username to connect to the service broker.
- Used for to authenticate all HTTP requests except to `/health`, `/metrics` and except if a https://tools.ietf.org/html/rfc7519[JWT] https://tools.ietf.org/html/rfc6750[`Bearer` token] is presented.
+|Username to use when connecting to this service broker.
+ Used to authenticate all HTTP requests, except to `/health`, `/metrics` and except if a https://tools.ietf.org/html/rfc7519[JWT] https://tools.ietf.org/html/rfc6750[`Bearer` token] is presented.
 |_MUST be provided, no default value is defined._
 |`service-catalogue`
 
 |`OSB_PASSWORD`
-|Password to connect to the service broker.
-Used for to authenticate all HTTP requests except to `/health`, `/metrics` and except if a `Bearer` token is presented.
+|Password to use when connecting to this service broker.
+Used to authenticate all HTTP requests except to `/health`, `/metrics` and except if a `Bearer` token is presented.
 |_MUST be provided, no default value is defined._
 |https://www.random.org/strings/?num=2&len=20&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new[Random String]
 
-|`OSB_NAMESPACE`
-|Which namespace the service broker shall use to create the resources.
-|_MUST be provided, no default_
-|`crossplane-service-broker`
+|`OSB_USERNAME_CLAIM`
+|If a https://tools.ietf.org/html/rfc7519[JWT] https://tools.ietf.org/html/rfc6750[`Bearer` token] is presented,
+then the value of this variable defines the claim that is considered to contain the username of the request principal.
+|`sub`
+|`email`
 
 |`OSB_HTTP_LISTEN_ADDR`
-|Which port to listen on
+|Which port to listen on for HTTP requests.
 |`:8080`
 |`:8000`
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -37,8 +37,7 @@ Used to authenticate all HTTP requests except to `/health`, `/metrics` and excep
 |https://www.random.org/strings/?num=2&len=20&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new[Random String]
 
 |`OSB_USERNAME_CLAIM`
-|If a https://tools.ietf.org/html/rfc7519[JWT] https://tools.ietf.org/html/rfc6750[`Bearer` token] is presented,
-then the value of this variable defines the claim that is considered to contain the username of the request principal.
+|If a https://tools.ietf.org/html/rfc7519[JWT] https://tools.ietf.org/html/rfc6750[`Bearer` token] is presented, then the value of this variable defines the claim that is considered to contain the username of the request principal.
 |`sub`
 |`email`
 

--- a/pkg/api/auth/middleware.go
+++ b/pkg/api/auth/middleware.go
@@ -25,29 +25,29 @@ type contextKey string
 
 const (
 	// AuthenticationMethodPropertyName allows to query the HTTP context for the authentication method used.
-	// See AuthorizationMethodBearerToken and AuthorizationMethodBasicAuth,
+	// See AuthenticationMethodBearerToken and AuthenticationMethodBasicAuth,
 	// as well as Context() on http.Request.
 	AuthenticationMethodPropertyName contextKey = "authentication-method"
 
-	// AuthorizationMethodBearerToken should be used to compare with the value returned by AuthenticationMethodPropertyName.
+	// AuthenticationMethodBearerToken should be used to compare with the value returned by AuthenticationMethodPropertyName.
 	//
 	//   func(w http.ResponseWriter, r *http.Request) {
 	//     method := r.Context().Value(auth.UserPropertyName);
-	//     if method == auth.AuthorizationMethodBearerToken {
+	//     if method == auth.AuthenticationMethodBearerToken {
 	//       // Bearer Token auth
 	//     }
 	//   }
-	AuthorizationMethodBearerToken = "Bearer"
+	AuthenticationMethodBearerToken = "Bearer"
 
-	// AuthorizationMethodBasicAuth should be used to compare with the value returned by AuthenticationMethodPropertyName:
+	// AuthenticationMethodBasicAuth should be used to compare with the value returned by AuthenticationMethodPropertyName:
 	//
 	//   func(w http.ResponseWriter, r *http.Request) {
 	//     method := r.Context().Value(auth.UserPropertyName);
-	//     if method == auth.AuthorizationMethodBasicAuth {
+	//     if method == auth.AuthenticationMethodBasicAuth {
 	//       // Basic auth
 	//     }
 	//   }
-	AuthorizationMethodBasicAuth = "Basic"
+	AuthenticationMethodBasicAuth = "Basic"
 )
 
 var (
@@ -103,12 +103,12 @@ func (a AuthenticationMiddleware) Handler(handler http.Handler) http.Handler {
 }
 
 func (a AuthenticationMiddleware) handleBasicAuth(w http.ResponseWriter, r *http.Request, handler http.Handler) {
-	ctx := context.WithValue(r.Context(), AuthenticationMethodPropertyName, AuthorizationMethodBasicAuth)
+	ctx := context.WithValue(r.Context(), AuthenticationMethodPropertyName, AuthenticationMethodBasicAuth)
 	a.basicAuth.Handler(handler).ServeHTTP(w, r.WithContext(ctx))
 }
 
 func (a AuthenticationMiddleware) handleBearerToken(w http.ResponseWriter, r *http.Request, handler http.Handler) {
-	ctx := context.WithValue(r.Context(), AuthenticationMethodPropertyName, AuthorizationMethodBearerToken)
+	ctx := context.WithValue(r.Context(), AuthenticationMethodPropertyName, AuthenticationMethodBearerToken)
 	a.bearerTokenAuth.Handler(handler).ServeHTTP(w, r.WithContext(ctx))
 }
 

--- a/pkg/api/auth/middleware.go
+++ b/pkg/api/auth/middleware.go
@@ -14,6 +14,8 @@ type authenticationHandler interface {
 	Handler(handler http.Handler) http.Handler
 }
 
+type principalReader func(req *http.Request) (Principal, error)
+
 // AuthenticationMiddleware represents a mux middleware which, given an http.Request, can check whether
 // it's Authorization header contains a valid BearerToken or – if not – valid Basic Auth information.
 type AuthenticationMiddleware struct {
@@ -37,7 +39,7 @@ const (
 	//       // Bearer Token auth
 	//     }
 	//   }
-	AuthorizationMethodBearerToken contextKey = "Bearer"
+	AuthorizationMethodBearerToken = "Bearer"
 
 	// AuthorizationMethodBasicAuth should be used to compare with the value returned by AuthenticationMethodPropertyName:
 	//
@@ -47,7 +49,7 @@ const (
 	//       // Basic auth
 	//     }
 	//   }
-	AuthorizationMethodBasicAuth contextKey = "Basic"
+	AuthorizationMethodBasicAuth = "Basic"
 )
 
 var (

--- a/pkg/api/auth/middleware.go
+++ b/pkg/api/auth/middleware.go
@@ -14,8 +14,6 @@ type authenticationHandler interface {
 	Handler(handler http.Handler) http.Handler
 }
 
-type principalReader func(req *http.Request) (Principal, error)
-
 // AuthenticationMiddleware represents a mux middleware which, given an http.Request, can check whether
 // it's Authorization header contains a valid BearerToken or – if not – valid Basic Auth information.
 type AuthenticationMiddleware struct {

--- a/pkg/api/auth/principal.go
+++ b/pkg/api/auth/principal.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pascaldekloe/jwt"
+)
+
+// Principal represents the entity (person or system) in who's name the current request is made.
+// It does not represent the _origin_ of the request.
+// For example, a system might send a request in the name of a person.
+type Principal struct {
+	Name string
+}
+
+// GetPrincipal extracts the Principal on who's name the given http.Request was made based on the information
+// that was retrieved with the http.Request in the Authorization HTTP header.
+func GetPrincipal(req *http.Request) (Principal, error) {
+	authenticationMethod := req.Context().Value(AuthenticationMethodPropertyName)
+	if authenticationMethod == nil {
+		return Principal{}, fmt.Errorf("likely an unauthorized request")
+	}
+
+	authenticationMethodStr, ok := authenticationMethod.(string)
+	if !ok {
+		return Principal{}, fmt.Errorf("can't convert authorization method to string")
+	}
+
+	var reader principalReader
+	switch {
+	case authenticationMethodStr == AuthorizationMethodBasicAuth:
+		reader = getPrincipalFromBasicAuth
+	case authenticationMethodStr == AuthorizationMethodBearerToken:
+		reader = getPrincipalFromBearerToken
+	default:
+		return Principal{}, fmt.Errorf("unknown authorication format '%s'", authenticationMethodStr)
+	}
+
+	return reader(req)
+}
+
+// getPrincipalFromBearerToken extracts the Principal on who's name the given http.Request was made based on the
+// Bearer token that was retrieved with the http.Request in the Authorization HTTP header.
+func getPrincipalFromBearerToken(req *http.Request) (Principal, error) {
+	token := req.Context().Value(TokenPropertyName)
+	if token == nil {
+		return Principal{}, fmt.Errorf("principal token not set")
+	}
+
+	claim, ok := token.(*jwt.Claims)
+	if !ok {
+		return Principal{}, fmt.Errorf("principal token is invalid")
+	}
+
+	claimName := "username" // TODO move hardcoded to configuration
+	username, ok := claim.String(claimName)
+	if !ok {
+		return Principal{}, fmt.Errorf("principal token contains no claim named '%s'", claimName)
+	}
+
+	return Principal{Name: username}, nil
+}
+
+// getPrincipalFromBasicAuth extracts the Principal on who's name the given http.Request was made based on the
+// Basic auth username that was retrieved with the http.Request in the Authorization HTTP header.
+func getPrincipalFromBasicAuth(req *http.Request) (Principal, error) {
+	userName := req.Context().Value(UserPropertyName)
+	if userName == nil {
+		return Principal{}, fmt.Errorf("principal not set")
+	}
+
+	userNameStr, ok := userName.(string)
+	if !ok {
+		return Principal{}, fmt.Errorf("principal is not a string")
+	}
+	return Principal{Name: userNameStr}, nil
+}

--- a/pkg/api/auth/principal.go
+++ b/pkg/api/auth/principal.go
@@ -13,7 +13,7 @@ import (
 // For example, a system might send a request in the name of a person.
 type Principal string
 
-// PrincipalFromContext extracts the Principal on who's name the given http.Request was made based on the information
+// PrincipalFromContext extracts the Principal on whose name the given http.Request was made based on the information
 // that was retrieved with the http.Request in the Authorization HTTP header.
 func PrincipalFromContext(ctx context.Context, cfg *config.Config) (Principal, error) {
 	authenticationMethod := ctx.Value(AuthenticationMethodPropertyName)
@@ -36,7 +36,7 @@ func PrincipalFromContext(ctx context.Context, cfg *config.Config) (Principal, e
 	}
 }
 
-// getPrincipalFromBearerToken extracts the Principal on who's name the given http.Request was made based on the
+// getPrincipalFromBearerToken extracts the Principal on whose name the given http.Request was made based on the
 // Bearer token that was retrieved with the http.Request in the Authorization HTTP header.
 func getPrincipalFromBearerToken(ctx context.Context, cfg *config.Config) (Principal, error) {
 	token := ctx.Value(TokenPropertyName)
@@ -57,7 +57,7 @@ func getPrincipalFromBearerToken(ctx context.Context, cfg *config.Config) (Princ
 	return Principal(username), nil
 }
 
-// getPrincipalFromBasicAuth extracts the Principal on who's name the given http.Request was made based on the
+// getPrincipalFromBasicAuth extracts the Principal on whose name the given http.Request was made based on the
 // Basic auth username that was retrieved with the http.Request in the Authorization HTTP header.
 func getPrincipalFromBasicAuth(ctx context.Context) (Principal, error) {
 	userName := ctx.Value(UserPropertyName)

--- a/pkg/api/auth/principal.go
+++ b/pkg/api/auth/principal.go
@@ -1,8 +1,8 @@
 package auth
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/pascaldekloe/jwt"
 	"github.com/vshn/crossplane-service-broker/pkg/config"
@@ -11,65 +11,63 @@ import (
 // Principal represents the entity (person or system) in who's name the current request is made.
 // It does not represent the _origin_ of the request.
 // For example, a system might send a request in the name of a person.
-type Principal struct {
-	Name string
-}
+type Principal string
 
-// FromRequest extracts the Principal on who's name the given http.Request was made based on the information
+// PrincipalFromContext extracts the Principal on who's name the given http.Request was made based on the information
 // that was retrieved with the http.Request in the Authorization HTTP header.
-func FromRequest(cfg *config.Config, req *http.Request) (Principal, error) {
-	authenticationMethod := req.Context().Value(AuthenticationMethodPropertyName)
+func PrincipalFromContext(ctx context.Context, cfg *config.Config) (Principal, error) {
+	authenticationMethod := ctx.Value(AuthenticationMethodPropertyName)
 	if authenticationMethod == nil {
-		return Principal{}, fmt.Errorf("likely an unauthorized request")
+		return "", fmt.Errorf("likely an unauthorized request")
 	}
 
 	authenticationMethodStr, ok := authenticationMethod.(string)
 	if !ok {
-		return Principal{}, fmt.Errorf("can't convert authorization method to string")
+		return "", fmt.Errorf("can't convert authorization method to string")
 	}
 
 	switch {
-	case authenticationMethodStr == AuthorizationMethodBasicAuth:
-		return getPrincipalFromBasicAuth(req)
-	case authenticationMethodStr == AuthorizationMethodBearerToken:
-		return getPrincipalFromBearerToken(cfg, req)
+	case authenticationMethodStr == AuthenticationMethodBasicAuth:
+		return getPrincipalFromBasicAuth(ctx)
+	case authenticationMethodStr == AuthenticationMethodBearerToken:
+		return getPrincipalFromBearerToken(ctx, cfg)
 	default:
-		return Principal{}, fmt.Errorf("unknown authorication format '%s'", authenticationMethodStr)
+		return "", fmt.Errorf("unknown authorication format '%s'", authenticationMethodStr)
 	}
 }
 
 // getPrincipalFromBearerToken extracts the Principal on who's name the given http.Request was made based on the
 // Bearer token that was retrieved with the http.Request in the Authorization HTTP header.
-func getPrincipalFromBearerToken(cfg *config.Config, req *http.Request) (Principal, error) {
-	token := req.Context().Value(TokenPropertyName)
+func getPrincipalFromBearerToken(ctx context.Context, cfg *config.Config) (Principal, error) {
+	token := ctx.Value(TokenPropertyName)
 	if token == nil {
-		return Principal{}, fmt.Errorf("principal token not set")
+		return "", fmt.Errorf("principal token not set")
 	}
 
 	claim, ok := token.(*jwt.Claims)
 	if !ok {
-		return Principal{}, fmt.Errorf("principal token is invalid")
+		return "", fmt.Errorf("principal token is invalid")
 	}
 
 	username, ok := claim.String(cfg.UsernameClaim)
 	if !ok {
-		return Principal{}, fmt.Errorf("principal token contains no claim named '%s'", cfg.UsernameClaim)
+		return "", fmt.Errorf("principal token contains no claim named '%s'", cfg.UsernameClaim)
 	}
 
-	return Principal{Name: username}, nil
+	return Principal(username), nil
 }
 
 // getPrincipalFromBasicAuth extracts the Principal on who's name the given http.Request was made based on the
 // Basic auth username that was retrieved with the http.Request in the Authorization HTTP header.
-func getPrincipalFromBasicAuth(req *http.Request) (Principal, error) {
-	userName := req.Context().Value(UserPropertyName)
+func getPrincipalFromBasicAuth(ctx context.Context) (Principal, error) {
+	userName := ctx.Value(UserPropertyName)
 	if userName == nil {
-		return Principal{}, fmt.Errorf("principal not set")
+		return "", fmt.Errorf("principal not set")
 	}
 
 	userNameStr, ok := userName.(string)
 	if !ok {
-		return Principal{}, fmt.Errorf("principal is not a string")
+		return "", fmt.Errorf("principal is not a string")
 	}
-	return Principal{Name: userNameStr}, nil
+	return Principal(userNameStr), nil
 }

--- a/pkg/api/auth/principal_test.go
+++ b/pkg/api/auth/principal_test.go
@@ -8,33 +8,51 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vshn/crossplane-service-broker/pkg/config"
 
 	"github.com/pascaldekloe/jwt"
 )
 
+var emptyEnv = map[string]string{
+	config.EnvServiceIDs: "test",
+	config.EnvUsername:   "test",
+	config.EnvPassword:   "test",
+	config.EnvNamespace:  "test",
+}
+
 func Test_BasicPrincipal(t *testing.T) {
+	cfg := givenConfiguration(t, emptyEnv)
 	givenUsername := "expectedUsername"
 	req := givenAuthenticatedRequest(t, AuthorizationMethodBasicAuth, UserPropertyName, givenUsername)
 
-	actualPrincipal, err := GetPrincipal(req)
+	actualPrincipal, err := FromRequest(cfg, req)
 
 	assert.NoError(t, err)
 	assert.Equal(t, givenUsername, actualPrincipal.Name)
 }
 
 func Test_BearerTokenPrincipal(t *testing.T) {
+	cfg := givenConfiguration(t, emptyEnv)
 	givenUsername := "expectedUsername"
 	givenToken := jwt.Claims{
 		Set: map[string]interface{}{
-			"username": givenUsername, // TODO get/set claim name in configuration
+			cfg.UsernameClaim: givenUsername,
 		},
 	}
 	req := givenAuthenticatedRequest(t, AuthorizationMethodBearerToken, TokenPropertyName, &givenToken)
 
-	actualPrincipal, err := GetPrincipal(req)
+	actualPrincipal, err := FromRequest(cfg, req)
 
 	assert.NoError(t, err)
 	assert.Equal(t, givenUsername, actualPrincipal.Name)
+}
+
+func givenConfiguration(t *testing.T, env map[string]string) *config.Config {
+	cfg, err := config.ReadConfig(func(s string) string {
+		return env[s]
+	})
+	require.NoError(t, err)
+	return cfg
 }
 
 func givenAuthenticatedRequest(t *testing.T, authMethod interface{}, expectedPrincipalKey interface{}, expectedPrincipalValue interface{}) *http.Request {

--- a/pkg/api/auth/principal_test.go
+++ b/pkg/api/auth/principal_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pascaldekloe/jwt"
+)
+
+func Test_BasicPrincipal(t *testing.T) {
+	givenUsername := "expectedUsername"
+	req := givenAuthenticatedRequest(t, AuthorizationMethodBasicAuth, UserPropertyName, givenUsername)
+
+	actualPrincipal, err := GetPrincipal(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, givenUsername, actualPrincipal.Name)
+}
+
+func Test_BearerTokenPrincipal(t *testing.T) {
+	givenUsername := "expectedUsername"
+	givenToken := jwt.Claims{
+		Set: map[string]interface{}{
+			"username": givenUsername, // TODO get/set claim name in configuration
+		},
+	}
+	req := givenAuthenticatedRequest(t, AuthorizationMethodBearerToken, TokenPropertyName, &givenToken)
+
+	actualPrincipal, err := GetPrincipal(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, givenUsername, actualPrincipal.Name)
+}
+
+func givenAuthenticatedRequest(t *testing.T, authMethod interface{}, expectedPrincipalKey interface{}, expectedPrincipalValue interface{}) *http.Request {
+	req, err := http.NewRequest("GET", "/whatever", &bytes.Buffer{})
+	require.NoError(t, err)
+	req = req.WithContext(context.WithValue(req.Context(), AuthenticationMethodPropertyName, authMethod))
+	req = req.WithContext(context.WithValue(req.Context(), expectedPrincipalKey, expectedPrincipalValue))
+	return req
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ const (
 	// EnvHTTPMaxHeaderBytes sets the maximum header size for HTTP requests.
 	EnvHTTPMaxHeaderBytes = "OSB_HTTP_MAX_HEADER_BYTES"
 
+	// EnvJWTKeyJWKURL sets the URL of a JWK file, which is used to validate the signatures of the JWT Bearer Tokens.
 	EnvJWTKeyJWKURL = "OSB_JWT_KEYS_JWK_URL"
 
 	// EnvJWTKeyPEMURL sets the URL of a PEM file, which is used to validate the signatures of the JWT Bearer Tokens.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -14,51 +13,86 @@ func Test_ReadConfig(t *testing.T) {
 		err    string
 	}{
 		"serviceIDs required": {
-			env:    map[string]string{},
+			env: map[string]string{
+				EnvUsername:  "user",
+				EnvPassword:  "password",
+				EnvNamespace: "namespace",
+			},
+			config: nil,
+			err:    "OSB_SERVICE_IDS is required, but was not defined or is empty",
+		},
+		"empty serviceIDs given": {
+			env: map[string]string{
+				EnvUsername:   "user",
+				EnvPassword:   "password",
+				EnvNamespace:  "namespace",
+				EnvServiceIDs: ",,,",
+			},
 			config: nil,
 			err:    "OSB_SERVICE_IDS is required, but was not defined or is empty",
 		},
 		"username required": {
 			env: map[string]string{
-				"OSB_SERVICE_IDS": "1,2,3",
+				EnvServiceIDs: "1,2,3",
 			},
 			config: nil,
 			err:    "OSB_USERNAME is required, but was not defined or is empty",
 		},
 		"password required": {
 			env: map[string]string{
-				"OSB_SERVICE_IDS": "1,2,3",
-				"OSB_USERNAME":    "user",
+				EnvServiceIDs: "1,2,3",
+				EnvUsername:   "user",
 			},
 			config: nil,
 			err:    "OSB_PASSWORD is required, but was not defined or is empty",
 		},
 		"namespace required": {
 			env: map[string]string{
-				"OSB_SERVICE_IDS": "1,2,3",
-				"OSB_USERNAME":    "user",
-				"OSB_PASSWORD":    "pw",
+				EnvServiceIDs: "1,2,3",
+				EnvUsername:   "user",
+				EnvPassword:   "pw",
 			},
 			config: nil,
 			err:    "OSB_NAMESPACE is required, but was not defined or is empty",
 		},
-		"defaults configured": {
+		"username claim given": {
 			env: map[string]string{
-				"OSB_SERVICE_IDS": "1,2,3",
-				"OSB_USERNAME":    "user",
-				"OSB_PASSWORD":    "pw",
-				"OSB_NAMESPACE":   "test",
+				EnvServiceIDs:    "1,2,3",
+				EnvUsername:      "user",
+				EnvPassword:      "pw",
+				EnvNamespace:     "test",
+				EnvUsernameClaim: "different than default",
 			},
 			config: &Config{
 				ServiceIDs:     []string{"1", "2", "3"},
 				ListenAddr:     ":8080",
 				Username:       "user",
 				Password:       "pw",
-				UsernameClaim:  "sub",
+				UsernameClaim:  "different than default",
 				Namespace:      "test",
-				ReadTimeout:    180 * time.Second,
-				WriteTimeout:   180 * time.Second,
-				MaxHeaderBytes: 1 << 20,
+				ReadTimeout:    defaultHTTPTimeout,
+				WriteTimeout:   defaultHTTPTimeout,
+				MaxHeaderBytes: defaultHTTPMaxHeaderBytes,
+			},
+			err: "",
+		},
+		"defaults configured": {
+			env: map[string]string{
+				EnvServiceIDs: "1,2,3",
+				EnvUsername:   "user",
+				EnvPassword:   "pw",
+				EnvNamespace:  "test",
+			},
+			config: &Config{
+				ServiceIDs:     []string{"1", "2", "3"},
+				ListenAddr:     defaultHTTPListenAddr,
+				Username:       "user",
+				Password:       "pw",
+				UsernameClaim:  defaultUsernameClaim,
+				Namespace:      "test",
+				ReadTimeout:    defaultHTTPTimeout,
+				WriteTimeout:   defaultHTTPTimeout,
+				MaxHeaderBytes: defaultHTTPMaxHeaderBytes,
 			},
 			err: "",
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,14 +16,14 @@ func Test_ReadConfig(t *testing.T) {
 		"serviceIDs required": {
 			env:    map[string]string{},
 			config: nil,
-			err:    "OSB_SERVICE_IDS is required",
+			err:    "OSB_SERVICE_IDS is required, but was not defined or is empty",
 		},
 		"username required": {
 			env: map[string]string{
 				"OSB_SERVICE_IDS": "1,2,3",
 			},
 			config: nil,
-			err:    "OSB_USERNAME is required",
+			err:    "OSB_USERNAME is required, but was not defined or is empty",
 		},
 		"password required": {
 			env: map[string]string{
@@ -31,7 +31,7 @@ func Test_ReadConfig(t *testing.T) {
 				"OSB_USERNAME":    "user",
 			},
 			config: nil,
-			err:    "OSB_PASSWORD is required",
+			err:    "OSB_PASSWORD is required, but was not defined or is empty",
 		},
 		"namespace required": {
 			env: map[string]string{
@@ -40,7 +40,7 @@ func Test_ReadConfig(t *testing.T) {
 				"OSB_PASSWORD":    "pw",
 			},
 			config: nil,
-			err:    "OSB_NAMESPACE is required",
+			err:    "OSB_NAMESPACE is required, but was not defined or is empty",
 		},
 		"defaults configured": {
 			env: map[string]string{
@@ -54,6 +54,7 @@ func Test_ReadConfig(t *testing.T) {
 				ListenAddr:     ":8080",
 				Username:       "user",
 				Password:       "pw",
+				UsernameClaim:  "sub",
 				Namespace:      "test",
 				ReadTimeout:    180 * time.Second,
 				WriteTimeout:   180 * time.Second,

--- a/pkg/crossplane/metadata.go
+++ b/pkg/crossplane/metadata.go
@@ -41,6 +41,8 @@ const (
 	UpdatableLabel = SynToolsBase + "/updatable"
 	// DeletedLabel marks an object as deleted to clean up
 	DeletedLabel = SynToolsBase + "/deleted"
+	// PrincipalLabel stores the username of the entity (person or system) that created the respective resource
+	PrincipalLabel = SynToolsBase + "/principal"
 
 	// SLAPremium represents the string for the premium SLA
 	SLAPremium = "premium"

--- a/pkg/crossplane/service_mariadb_database.go
+++ b/pkg/crossplane/service_mariadb_database.go
@@ -118,7 +118,7 @@ func (msb MariadbDatabaseServiceBinder) Unbind(ctx context.Context, bindingID st
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(secretName, bindingID),
-			Namespace: msb.cp.namespace,
+			Namespace: msb.cp.config.Namespace,
 		},
 	}
 	return msb.cp.client.Delete(ctx, secret)
@@ -193,7 +193,7 @@ func (msb MariadbDatabaseServiceBinder) createBinding(ctx context.Context, bindi
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(secretName, bindingID),
-			Namespace: msb.cp.namespace,
+			Namespace: msb.cp.config.Namespace,
 			Labels:    labels,
 		},
 		Data: map[string][]byte{


### PR DESCRIPTION
## Summary

This PR adds information about the HTTP request principal (extracted from either the Basic auth username or from a claim of the JWT token presented in Bearer token auth).

Besides, the PR adds this:

- Improved configuration sanity checks:
  - Only empty values are substituted with default values.
  - An error is thrown, when a value is given, but it can't be parsed (e.g. parsing ints or durations).
  - The error messages have been improved as well
- In some functions, cohesive functionality has been extracted into a separate function

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [x] Update the documentation.
- [x] Update tests.
- [ ] ~~Link this PR to related issues.~~

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
