### PR TITLE
JWKeyRegister must be passed by reference

### DIFF
--- a/cmd/crossplane-service-broker/main.go
+++ b/cmd/crossplane-service-broker/main.go
@@ -72,7 +72,7 @@ func run(signalChan chan os.Signal, logger lager.Logger) error {
 	b := brokerapi.New(cp, logger.WithData(lager.Data{"component": "brokerapi"}))
 
 	serviceBrokerCredential := auth.SingleCredential(cfg.Username, cfg.Password)
-	a := api.New(b, serviceBrokerCredential, &cfg.JWKeyRegister, logger.WithData(lager.Data{"component": "api"}))
+	a := api.New(b, serviceBrokerCredential, cfg.JWKeyRegister, logger.WithData(lager.Data{"component": "api"}))
 	router.NewRoute().Handler(a)
 
 	srv := http.Server{

--- a/pkg/api/auth/bearer_token.go
+++ b/pkg/api/auth/bearer_token.go
@@ -27,10 +27,6 @@ const TokenPropertyName = "bearer-token"
 
 // Handler represents a mux.MiddlewareFunc
 func (t *BearerToken) Handler(handler http.Handler) http.Handler {
-	if t.Keys == nil { // things to terribly wrong if Keys is nil
-		t.Keys = &jwt.KeyRegister{}
-	}
-
 	return &jwt.Handler{
 		Target:     handler,
 		Keys:       t.Keys,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/pascaldekloe/jwt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,6 +74,7 @@ func Test_ReadConfig(t *testing.T) {
 				ReadTimeout:    defaultHTTPTimeout,
 				WriteTimeout:   defaultHTTPTimeout,
 				MaxHeaderBytes: defaultHTTPMaxHeaderBytes,
+				JWKeyRegister:  &jwt.KeyRegister{},
 			},
 			err: "",
 		},
@@ -93,6 +95,7 @@ func Test_ReadConfig(t *testing.T) {
 				ReadTimeout:    defaultHTTPTimeout,
 				WriteTimeout:   defaultHTTPTimeout,
 				MaxHeaderBytes: defaultHTTPMaxHeaderBytes,
+				JWKeyRegister:  &jwt.KeyRegister{},
 			},
 			err: "",
 		},


### PR DESCRIPTION
## Summary

For some keys, the `JWKeyRegister` must be passed by reference instead of by value. Otherwise the `JWTKeyRegister` will just be empty for these types of keys.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
