### PR TITLE
Set correct instance_id in metrics endpoint URL

### DIFF
--- a/pkg/brokerapi/brokerapi_test.go
+++ b/pkg/brokerapi/brokerapi_test.go
@@ -1082,9 +1082,9 @@ func (ts *EnvTestSuite) TestBrokerAPI_Bind() {
 					"jdbcUrl":        "***",
 					"jdbcUrlMariaDb": "***",
 					"metricsEndpoints": []string{
-						"http://1-2-1-mariadb-0.dbaas-test-cluster.metrics.example.tld",
-						"http://1-2-1-mariadb-1.dbaas-test-cluster.metrics.example.tld",
-						"http://1-2-1-mariadb-2.dbaas-test-cluster.metrics.example.tld",
+						"http://1-1-1-mariadb-0.dbaas-test-cluster.metrics.example.tld",
+						"http://1-1-1-mariadb-1.dbaas-test-cluster.metrics.example.tld",
+						"http://1-1-1-mariadb-2.dbaas-test-cluster.metrics.example.tld",
 					},
 				},
 			},


### PR DESCRIPTION
The URL holds the name of the db cluster instance and not the database
object itself

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>

## Summary



<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
