### PR TITLE
Fix race condition in MariaDB unbinding

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -35,6 +35,8 @@ CROSSPLANE_CRDS = $(addprefix $(TESTDATA_CRD_DIR)/, apiextensions.crossplane.io_
 					pkg.crossplane.io_providerrevisions.yaml \
 					pkg.crossplane.io_providers.yaml)
 
+PROVIDERSQL_VERSION = v0.2.1
+
 # Image URL to use all building/pushing image targets
 DOCKER_IMG ?= docker.io/vshn/crossplane-service-broker:$(IMG_TAG)
 QUAY_IMG ?= quay.io/vshn/crossplane-service-broker:$(IMG_TAG)

--- a/pkg/api/auth/basic.go
+++ b/pkg/api/auth/basic.go
@@ -13,11 +13,11 @@ import (
 // UserPropertyName allows to query the HTTP context for the current user's name.
 // See Context() on http.Request.
 //
-//   func(w http.ResponseWriter, r *http.Request) {
-//     user := r.Context().Value(auth.UserPropertyName);
-//     fmt.Fprintf(w, "This is an authenticated request")
-//     fmt.Fprintf(w, "User name: '%s'\n", user)
-//   }
+//	func(w http.ResponseWriter, r *http.Request) {
+//	  user := r.Context().Value(auth.UserPropertyName);
+//	  fmt.Fprintf(w, "This is an authenticated request")
+//	  fmt.Fprintf(w, "User name: '%s'\n", user)
+//	}
 const UserPropertyName contextKey = "user"
 
 // Basic represents a mux middleware that, given a http.Request, checks whether the Authorization header
@@ -26,7 +26,7 @@ type Basic struct {
 	Credentials []Credential
 }
 
-// Credential represents one user's ``username and password'' combination.
+// Credential represents one user's “username and password” combination.
 type Credential struct {
 	username []byte
 	password []byte

--- a/pkg/api/auth/bearer_token.go
+++ b/pkg/api/auth/bearer_token.go
@@ -15,14 +15,14 @@ type BearerToken struct {
 // TokenPropertyName allows to query the HTTP context for the current user's JWT token.
 // See Context() on http.Request.
 //
-//   func(w http.ResponseWriter, r *http.Request) {
-//     claims := req.Context().Value(auth.TokenPropertyName).(*jwt.Claims)
-//     if n, ok := claims.Number("deadline"); !ok {
-//       fmt.Fprintln(w, "no deadline")
-//     } else {
-//       fmt.Fprintln(w, "deadline at", (*jwt.NumericTime)(&n))
-//     }
-//   }
+//	func(w http.ResponseWriter, r *http.Request) {
+//	  claims := req.Context().Value(auth.TokenPropertyName).(*jwt.Claims)
+//	  if n, ok := claims.Number("deadline"); !ok {
+//	    fmt.Fprintln(w, "no deadline")
+//	  } else {
+//	    fmt.Fprintln(w, "deadline at", (*jwt.NumericTime)(&n))
+//	  }
+//	}
 const TokenPropertyName = "bearer-token"
 
 // Handler represents a mux.MiddlewareFunc

--- a/pkg/brokerapi/brokerapi.go
+++ b/pkg/brokerapi/brokerapi.go
@@ -30,7 +30,8 @@ func New(cp *crossplane.Crossplane, logger lager.Logger, pc crossplane.PlanUpdat
 }
 
 // Services gets the catalog of services offered by the service broker
-//   GET /v2/catalog
+//
+//	GET /v2/catalog
 func (b BrokerAPI) Services(ctx context.Context) ([]domain.Service, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, nil)
 	rctx.Logger.Info("get-catalog")
@@ -40,7 +41,8 @@ func (b BrokerAPI) Services(ctx context.Context) ([]domain.Service, error) {
 }
 
 // Provision creates a new service instance
-//   PUT /v2/service_instances/{instance_id}
+//
+//	PUT /v2/service_instances/{instance_id}
 func (b BrokerAPI) Provision(ctx context.Context, instanceID string, details domain.ProvisionDetails, asyncAllowed bool) (domain.ProvisionedServiceSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -58,7 +60,8 @@ func (b BrokerAPI) Provision(ctx context.Context, instanceID string, details dom
 }
 
 // Deprovision deletes an existing service instance
-//  DELETE /v2/service_instances/{instance_id}
+//
+//	DELETE /v2/service_instances/{instance_id}
 func (b BrokerAPI) Deprovision(ctx context.Context, instanceID string, details domain.DeprovisionDetails, asyncAllowed bool) (domain.DeprovisionServiceSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -72,7 +75,8 @@ func (b BrokerAPI) Deprovision(ctx context.Context, instanceID string, details d
 }
 
 // GetInstance fetches information about a service instance
-//   GET /v2/service_instances/{instance_id}
+//
+//	GET /v2/service_instances/{instance_id}
 func (b BrokerAPI) GetInstance(ctx context.Context, instanceID string, details domain.FetchInstanceDetails) (domain.GetInstanceDetailsSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -84,7 +88,8 @@ func (b BrokerAPI) GetInstance(ctx context.Context, instanceID string, details d
 }
 
 // Update modifies an existing service instance
-//  PATCH /v2/service_instances/{instance_id}
+//
+//	PATCH /v2/service_instances/{instance_id}
 func (b BrokerAPI) Update(ctx context.Context, instanceID string, details domain.UpdateDetails, asyncAllowed bool) (domain.UpdateServiceSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -106,7 +111,8 @@ func (b BrokerAPI) Update(ctx context.Context, instanceID string, details domain
 }
 
 // LastOperation fetches last operation state for a service instance
-//   GET /v2/service_instances/{instance_id}/last_operation
+//
+//	GET /v2/service_instances/{instance_id}/last_operation
 func (b BrokerAPI) LastOperation(ctx context.Context, instanceID string, details domain.PollDetails) (domain.LastOperation, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -120,7 +126,8 @@ func (b BrokerAPI) LastOperation(ctx context.Context, instanceID string, details
 }
 
 // Bind creates a new service binding
-//   PUT /v2/service_instances/{instance_id}/service_bindings/{binding_id}
+//
+//	PUT /v2/service_instances/{instance_id}/service_bindings/{binding_id}
 func (b BrokerAPI) Bind(ctx context.Context, instanceID, bindingID string, details domain.BindDetails, asyncAllowed bool) (domain.Binding, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -135,7 +142,8 @@ func (b BrokerAPI) Bind(ctx context.Context, instanceID, bindingID string, detai
 }
 
 // Unbind deletes an existing service binding
-//   DELETE /v2/service_instances/{instance_id}/service_bindings/{binding_id}
+//
+//	DELETE /v2/service_instances/{instance_id}/service_bindings/{binding_id}
 func (b BrokerAPI) Unbind(ctx context.Context, instanceID, bindingID string, details domain.UnbindDetails, asyncAllowed bool) (domain.UnbindSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,
@@ -150,7 +158,9 @@ func (b BrokerAPI) Unbind(ctx context.Context, instanceID, bindingID string, det
 }
 
 // GetBinding fetches an existing service binding
-//   GET /v2/service_instances/{instance_id}/service_bindings/{binding_id}
+//
+//	GET /v2/service_instances/{instance_id}/service_bindings/{binding_id}
+//
 // TODO(mw): adjust to use details.PlanID when https://github.com/pivotal-cf/brokerapi/pull/138 is merged.
 func (b BrokerAPI) GetBinding(ctx context.Context, instanceID, bindingID string, details domain.FetchBindingDetails) (domain.GetBindingSpec, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
@@ -164,7 +174,8 @@ func (b BrokerAPI) GetBinding(ctx context.Context, instanceID, bindingID string,
 }
 
 // LastBindingOperation fetches last operation state for a service binding
-//   GET /v2/service_instances/{instance_id}/service_bindings/{binding_id}/last_operation
+//
+//	GET /v2/service_instances/{instance_id}/service_bindings/{binding_id}/last_operation
 func (b BrokerAPI) LastBindingOperation(ctx context.Context, instanceID, bindingID string, details domain.PollDetails) (domain.LastOperation, error) {
 	rctx := reqcontext.NewReqContext(ctx, b.logger, lager.Data{
 		"instance-id": instanceID,

--- a/pkg/crossplane/client.go
+++ b/pkg/crossplane/client.go
@@ -170,8 +170,9 @@ func (cp Crossplane) Plan(rctx *reqcontext.ReqContext, planID string) (*Plan, er
 // The `ok` parameter is *only* set to true if no error is returned and the instance already exists.
 // Normal errors are returned as-is.
 // FIXME(mw): is it correct to return `false, errInstanceNotFound` if PlanNameLabel does not match? And how should that be handled?
-//            Ported from PoC code as-is, and errInstanceNotFound is handled as instance really not found, however as the ID exists, how
-//            can we speak about having no instance with that name? It's a UUID after all.
+//
+//	Ported from PoC code as-is, and errInstanceNotFound is handled as instance really not found, however as the ID exists, how
+//	can we speak about having no instance with that name? It's a UUID after all.
 func (cp Crossplane) Instance(rctx *reqcontext.ReqContext, id string, plan *Plan) (inst *Instance, ok bool, err error) {
 	gvk, err := plan.GVK()
 	if err != nil {

--- a/testdata/crds/mysql.sql.crossplane.io_users.yaml
+++ b/testdata/crds/mysql.sql.crossplane.io_users.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: users.mysql.sql.crossplane.io
+spec:
+  group: mysql.sql.crossplane.io
+  names:
+    categories:
+      - crossplane
+      - managed
+      - sql
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: READY
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Synced')].status
+          name: SYNCED
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: A User represents the declarative state of a MySQL user.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
## Summary

This PR fixes a race condition in the MariaDB database undbinding, that caused reconciliation errors in crossplane.


### Current behavior and issue

When binding to a mariaDB database, the broker will create a composite resource to provision the database user and grant and a secret that will be referenced by the mysql `User` object.

When unbinding the broker will first delete the composite resource, wait 5 seconds and then delete the secret. This is a race condition as for large clusters crossplane can take more than 5 seconds to reconcile the composite resource and delete the mysql `User` object. If the secret is deleted before the `User`, reconciliation will fail.

### New behavior

Instead of directly deleting the secret, the broker now adds an owner reference to the secret that points to the mysql `User` object. This means once the `User` object is reconciled and deleted, k8s will cleanup the secret. This way the secret will always be deleted after the user is removed.

### Notes

* The first PR does some formatting change. It seems like gofmt had a slight change since the last time this was touched.
* This could also have been fixed by upgrading crossplane to that latest version. But as we're running a very old version with a custom patch, I prefer to fix this in the broker

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [x] Update tests.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
