### PR TITLE
Block Redis 7.2 upgrade

### DIFF
--- a/pkg/crossplane/metadata.go
+++ b/pkg/crossplane/metadata.go
@@ -51,6 +51,8 @@ const (
 	OwnerGroupLabel = AppcatBase + "/ownergroup"
 	//OwnerKindLabel stores the kind of the composite
 	OwnerKindLabel = AppcatBase + "/ownerkind"
+	// VersionLabel stores the version of the service
+	VersionLabel = AppcatBase + "/version"
 )
 
 // Labels provides uniform access to parsed labels.
@@ -68,6 +70,7 @@ type Labels struct {
 	OwnerApiVersion string
 	OwnerGroup      string
 	OwnerKind       string
+	Version         string
 }
 
 func parseLabels(l map[string]string) (*Labels, error) {
@@ -86,6 +89,7 @@ func parseLabels(l map[string]string) (*Labels, error) {
 		OwnerApiVersion: l[OwnerApiVersionLabel],
 		OwnerGroup:      l[OwnerGroupLabel],
 		OwnerKind:       l[OwnerKindLabel],
+		Version:         l[VersionLabel],
 	}
 	var err error
 

--- a/pkg/crossplane/metadata_test.go
+++ b/pkg/crossplane/metadata_test.go
@@ -45,6 +45,7 @@ func Test_parseLabels(t *testing.T) {
 				OwnerApiVersionLabel: "v1alpha1",
 				OwnerGroupLabel:      "syn.tools",
 				OwnerKindLabel:       "CompositeFooInstance",
+				VersionLabel:         "7.2",
 			},
 			want: &Labels{
 				ServiceName:     RedisService,
@@ -60,6 +61,7 @@ func Test_parseLabels(t *testing.T) {
 				OwnerApiVersion: "v1alpha1",
 				OwnerGroup:      "syn.tools",
 				OwnerKind:       "CompositeFooInstance",
+				Version:         "7.2",
 			},
 			wantErr: false,
 		},
@@ -75,6 +77,7 @@ func Test_parseLabels(t *testing.T) {
 				BindableLabel:    "false",
 				UpdatableLabel:   "true",
 				DeletedLabel:     "true",
+				VersionLabel:     "6.2",
 			},
 			want: &Labels{
 				ServiceName: RedisService,
@@ -87,6 +90,7 @@ func Test_parseLabels(t *testing.T) {
 				Bindable:    false,
 				Updatable:   true,
 				Deleted:     true,
+				Version:     "6.2",
 			},
 			wantErr: false,
 		},

--- a/pkg/crossplane/plan.go
+++ b/pkg/crossplane/plan.go
@@ -109,6 +109,11 @@ func (pc PlanUpdateChecker) AllowUpdate(a, b Plan) bool {
 		return false
 	}
 
+	if planRedis72Changed(a, b) {
+		// Do not allow upgrade or downgrade Redis with version 7.2
+		return false
+	}
+
 	if planSizeChanged(a, b) {
 		return pc.allowSizeUpdate(a, b)
 	}
@@ -141,6 +146,13 @@ func planSizeChanged(a, b Plan) bool {
 
 func planSLAChanged(a, b Plan) bool {
 	return a.Labels != nil && b.Labels != nil && a.Labels.SLA != b.Labels.SLA
+}
+
+func planRedis72Changed(a, b Plan) bool {
+	if a.Labels == nil || b.Labels == nil {
+		return false
+	}
+	return (a.Labels.Version == "7.2") != (b.Labels.Version == "7.2")
 }
 
 func newPlan(c xv1.Composition) (*Plan, error) {

--- a/pkg/crossplane/plan_test.go
+++ b/pkg/crossplane/plan_test.go
@@ -151,3 +151,76 @@ func Test_PlanComparer(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanRedis72Changed(t *testing.T) {
+	tests := []struct {
+		desc     string
+		a        Plan
+		b        Plan
+		expected bool
+	}{
+		{
+			desc:     "Both nil labels",
+			a:        Plan{Labels: nil},
+			b:        Plan{Labels: nil},
+			expected: false,
+		},
+		{
+			desc:     "First plan has nil labels, second has non-7.2",
+			a:        Plan{Labels: nil},
+			b:        Plan{Labels: &Labels{Version: "7.0"}},
+			expected: false,
+		},
+		{
+			desc:     "First plan has nil labels, second has 7.2",
+			a:        Plan{Labels: nil},
+			b:        Plan{Labels: &Labels{Version: "7.2"}},
+			expected: false,
+		},
+		{
+			desc:     "First has non-7.2, second nil labels",
+			a:        Plan{Labels: &Labels{Version: "7.0"}},
+			b:        Plan{Labels: nil},
+			expected: false,
+		},
+		{
+			desc:     "First has 7.2, second nil labels",
+			a:        Plan{Labels: &Labels{Version: "7.2"}},
+			b:        Plan{Labels: nil},
+			expected: false,
+		},
+		{
+			desc:     "Both have the same version 7.2",
+			a:        Plan{Labels: &Labels{Version: "7.2"}},
+			b:        Plan{Labels: &Labels{Version: "7.2"}},
+			expected: false,
+		},
+		{
+			desc:     "Both have the same non-7.2 version",
+			a:        Plan{Labels: &Labels{Version: "7.0"}},
+			b:        Plan{Labels: &Labels{Version: "7.0"}},
+			expected: false,
+		},
+		{
+			desc:     "First has 7.2, second has different version",
+			a:        Plan{Labels: &Labels{Version: "7.2"}},
+			b:        Plan{Labels: &Labels{Version: "7.0"}},
+			expected: true,
+		},
+		{
+			desc:     "First has non-7.2, second has 7.2",
+			a:        Plan{Labels: &Labels{Version: "7.0"}},
+			b:        Plan{Labels: &Labels{Version: "7.2"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			result := planRedis72Changed(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.desc, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This update will block any update or downgrade of Redis 7.2 instances. 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
