### PR TITLE
Changes for more general usage

### DIFF
--- a/pkg/brokerapi/domain.go
+++ b/pkg/brokerapi/domain.go
@@ -43,6 +43,10 @@ func newServicePlan(plan *crossplane.Plan, logger lager.Logger) domain.ServicePl
 		logger.Error("parse-metadata", err, lager.Data{"plan": plan.Composition.Name})
 		meta.DisplayName = planName
 	}
+	schemas := &domain.ServiceSchemas{}
+	if err := json.Unmarshal([]byte(plan.Schemas), schemas); err != nil {
+		logger.Info("parse-schemas", lager.Data{"msg": "No schemas or not parsable", "plan": plan.Composition.Name})
+	}
 	return domain.ServicePlan{
 		ID:          plan.Composition.Name,
 		Name:        planName,
@@ -50,5 +54,6 @@ func newServicePlan(plan *crossplane.Plan, logger lager.Logger) domain.ServicePl
 		Free:        pointer.BoolPtr(false),
 		Bindable:    &plan.Labels.Bindable,
 		Metadata:    meta,
+		Schemas:     schemas,
 	}
 }

--- a/pkg/crossplane/client.go
+++ b/pkg/crossplane/client.go
@@ -270,7 +270,14 @@ func (cp Crossplane) prepareLabels(rctx *reqcontext.ReqContext, id string, plan 
 	// Copy relevant labels from plan
 	planLabels := []string{ServiceIDLabel, ServiceNameLabel, PlanNameLabel, ClusterLabel, SLALabel, OwnerApiVersionLabel, OwnerGroupLabel, OwnerKindLabel}
 	for _, name := range planLabels {
-		l[name] = plan.Composition.Labels[name]
+		// for each name, take either the param in the context or the label in the object
+		// this precedence is because we have control of the object labels more easily than what the broker client passes
+		if val, ok := params[name]; ok {
+			l[name] = val.(string)
+		}
+		if val, ok := plan.Composition.Labels[name]; ok {
+			l[name] = val
+		}
 	}
 
 	// slightly ugly having this service specific label setting leaking out to the generic code. Can be cleaned up later

--- a/pkg/crossplane/metadata.go
+++ b/pkg/crossplane/metadata.go
@@ -19,6 +19,8 @@ const (
 	DeletionTimestampAnnotation = SynToolsBase + "/deletionTimestamp"
 	// TagsAnnotation of the instance
 	TagsAnnotation = SynToolsBase + "/tags"
+	// TagsAnnotation of the instance
+	SchemaAnnotation = SynToolsBase + "/schemas"
 )
 
 const (
@@ -88,10 +90,6 @@ func parseLabels(l map[string]string) (*Labels, error) {
 		OwnerKind:       l[OwnerKindLabel],
 	}
 	var err error
-
-	if !md.ServiceName.IsValid() {
-		return nil, fmt.Errorf("service %q not valid", md.ServiceName)
-	}
 
 	md.Bindable, err = parseBoolLabel(l[BindableLabel], true)
 	if err != nil {

--- a/pkg/crossplane/plan.go
+++ b/pkg/crossplane/plan.go
@@ -32,6 +32,7 @@ type Plan struct {
 	Metadata    string
 	Tags        string
 	Description string
+	Schemas     string
 }
 
 // GVK returns the group, version, kind type for the composite type ref.
@@ -154,5 +155,6 @@ func newPlan(c xv1.Composition) (*Plan, error) {
 		Metadata:    c.Annotations[MetadataAnnotation],
 		Tags:        c.Annotations[TagsAnnotation],
 		Description: c.Annotations[DescriptionAnnotation],
+		Schemas:     c.Annotations[SchemaAnnotation],
 	}, nil
 }

--- a/pkg/crossplane/service_generic.go
+++ b/pkg/crossplane/service_generic.go
@@ -1,0 +1,55 @@
+package crossplane
+
+import (
+	"context"
+	"encoding/json"
+
+	"code.cloudfoundry.org/lager"
+)
+
+// GenericServiceBinder defines a specific Mariadb service with enough data to retrieve connection credentials.
+type GenericServiceBinder struct {
+	serviceBinder
+}
+
+// NewGenericServiceBinder instantiates a Mariadb service instance based on the given CompositeMariadbInstance.
+func NewGenericServiceBinder(c *Crossplane, instance *Instance, logger lager.Logger) *GenericServiceBinder {
+	return &GenericServiceBinder{
+		serviceBinder: serviceBinder{
+			instance: instance,
+			cp:       c,
+			logger:   logger,
+		},
+	}
+}
+
+func (g GenericServiceBinder) Bind(ctx context.Context, bindingID string) (Credentials, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g GenericServiceBinder) Unbind(ctx context.Context, bindingID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g GenericServiceBinder) Deprovisionable(ctx context.Context) error {
+	//TODO this should check to make sure instances are free
+	return nil
+}
+
+func (g GenericServiceBinder) GetBinding(ctx context.Context, bindingID string) (Credentials, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g GenericServiceBinder) ValidateProvisionParams(ctx context.Context, params json.RawMessage) (map[string]interface{}, error) {
+	var dat map[string]interface{}
+	if err := json.Unmarshal(params, &dat); err != nil {
+		return nil, err
+	}
+
+	// @fixme: How to map site-specific labels?
+	dat[ClusterLabel] = dat["subdomain"]
+	return dat, nil
+}

--- a/pkg/crossplane/service_generic.go
+++ b/pkg/crossplane/service_generic.go
@@ -2,7 +2,6 @@ package crossplane
 
 import (
 	"context"
-	"encoding/json"
 
 	"code.cloudfoundry.org/lager"
 )
@@ -43,13 +42,8 @@ func (g GenericServiceBinder) GetBinding(ctx context.Context, bindingID string) 
 	panic("implement me")
 }
 
-func (g GenericServiceBinder) ValidateProvisionParams(ctx context.Context, params json.RawMessage) (map[string]interface{}, error) {
-	var dat map[string]interface{}
-	if err := json.Unmarshal(params, &dat); err != nil {
-		return nil, err
-	}
-
+func (g GenericServiceBinder) ValidateProvisionParams(ctx context.Context, params map[string]interface{}) (map[string]interface{}, error) {
 	// @fixme: How to map site-specific labels?
-	dat[ClusterLabel] = dat["subdomain"]
-	return dat, nil
+	params[ClusterLabel] = params["subdomain"]
+	return params, nil
 }

--- a/pkg/crossplane/service_mariadb_database.go
+++ b/pkg/crossplane/service_mariadb_database.go
@@ -2,7 +2,6 @@ package crossplane
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -208,11 +207,7 @@ func (msb MariadbDatabaseServiceBinder) GetBinding(ctx context.Context, bindingI
 }
 
 // ValidateProvisionParams ensures the passed parent reference is an existing mariadb instance.
-func (msb MariadbDatabaseServiceBinder) ValidateProvisionParams(ctx context.Context, params json.RawMessage) (map[string]interface{}, error) {
-	paramsMap := map[string]interface{}{}
-	if err := json.Unmarshal(params, &paramsMap); err != nil {
-		return nil, err
-	}
+func (msb MariadbDatabaseServiceBinder) ValidateProvisionParams(ctx context.Context, paramsMap map[string]interface{}) (map[string]interface{}, error) {
 	parentRef, err := getParentRef(paramsMap)
 	if err != nil {
 		return nil, err

--- a/pkg/crossplane/service_redis.go
+++ b/pkg/crossplane/service_redis.go
@@ -2,7 +2,6 @@ package crossplane
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -110,29 +109,22 @@ func (rsb RedisServiceBinder) GetBinding(ctx context.Context, bindingID string) 
 
 // ValidateProvisionParams doesn't currently validate anything, it will simply take the params and convert them to
 // a map. This is because there are multiple Redis implementations, one has parameters and the other doesn't.
-func (rsb *RedisServiceBinder) ValidateProvisionParams(_ context.Context, params json.RawMessage) (map[string]interface{}, error) {
-	validatedParams := map[string]any{}
-
-	err := json.Unmarshal(params, &validatedParams)
-	if err != nil {
-		return validatedParams, fmt.Errorf("cannot unmarshal parameters: %w", err)
-	}
-
+func (rsb *RedisServiceBinder) ValidateProvisionParams(ctx context.Context, params map[string]interface{}) (map[string]interface{}, error) {
 	// SPKS's broker GUI can't handle booleans, instead it creates an array of items that were ticked.
 	// we need to parse that an convert to a boolean.
 	// If the `tls` button wasn't set, the array will be null. We rewrite the array to a
 	// boolean.
-	if validatedParams["tls"] != nil && interfaceIsSlice(validatedParams["tls"]) {
+	if params["tls"] != nil && interfaceIsSlice(params["tls"]) {
 		// we don't really care what type of elements it contains. If it
 		// contains any element at all, we assume tls should get enabled.
-		if reflect.ValueOf(validatedParams["tls"]).Len() >= 1 {
-			validatedParams["tls"] = true
+		if reflect.ValueOf(params["tls"]).Len() >= 1 {
+			params["tls"] = true
 		} else {
-			validatedParams["tls"] = false
+			params["tls"] = false
 		}
 	}
 
-	return validatedParams, nil
+	return params, nil
 }
 
 func interfaceIsSlice(t interface{}) bool {

--- a/pkg/crossplane/services.go
+++ b/pkg/crossplane/services.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"code.cloudfoundry.org/lager"
 )
@@ -74,8 +73,9 @@ func ServiceBinderFactory(c *Crossplane, serviceName ServiceName, instance *Inst
 		return NewMariadbServiceBinder(c, instance, logger), nil
 	case MariaDBDatabaseService:
 		return NewMariadbDatabaseServiceBinder(c, instance, logger), nil
+	default:
+		return NewGenericServiceBinder(c, instance, logger), nil
 	}
-	return nil, fmt.Errorf("service binder %q not implemented", serviceName)
 }
 
 type serviceBinder struct {

--- a/pkg/crossplane/services.go
+++ b/pkg/crossplane/services.go
@@ -2,7 +2,6 @@ package crossplane
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"code.cloudfoundry.org/lager"
@@ -60,7 +59,7 @@ type ServiceBinder interface {
 type ProvisionValidater interface {
 	// ValidateProvisionParams can be used to check the params for validity. If valid, it should return all needed parameters
 	// for the composition.
-	ValidateProvisionParams(ctx context.Context, params json.RawMessage) (map[string]interface{}, error)
+	ValidateProvisionParams(ctx context.Context, params map[string]interface{}) (map[string]interface{}, error)
 }
 
 // ServiceBinderFactory reads the composite's labels service name and instantiates an appropriate ServiceBinder.


### PR DESCRIPTION
## Summary
Thanks for publishing this work! At SAP, we use the Open Service Broker API to for publishing services into the SAP Service Manager (https://help.sap.com/docs/service-manager/sap-service-manager/sap-service-manager). I have found your broker works very well to enable Crossplane composites to both publish catalog entries and manage service lifecycles. 

I have made a small number of adaptations to enable some aspects of our implementations. I am not an expert on the OSBAPI, so I am presenting these changes with the intent to have your team help me better understand whether they are appropriate or not. The existing code has a concept of a generic service, but the code filters for and rejects service names that it does not recognize. Additionally, some contextual aspects of our service manager calls are bound to the request context. Lastly, we use the schemas functionality to present user interface for a parameters and I added a new annotation for those. 

Would be grateful to review these changes with your team and see if they are appropriate for merging!

## Changes
* Refactor service interface to receive request context (broker.go, service implementations)
* Include OSB schemas in the annotation set (domain.go, metadata.go, plan.go, )
* Modify deprovisioning of service that is not found (eg deleted at the control plane) to silently succeed (brokerapi.go)
* Accept plan labels from the broker request (client.go)
* Remove unreachable code for generic service (services.go)


