### PR TITLE
Fix wrong deletion ordering for Users

### DIFF
--- a/pkg/brokerapi/brokerapi_test.go
+++ b/pkg/brokerapi/brokerapi_test.go
@@ -1809,7 +1809,6 @@ func (ts *EnvTestSuite) TestBrokerAPI_Unbind() {
 			}, userInstance)
 			if err != nil {
 				ts.Assert().True(apierrors.IsNotFound(err))
-				ts.Assert().NoError(err)
 			} else {
 				ts.Assert().NotNil(userInstance.GetDeletionTimestamp())
 			}

--- a/pkg/crossplane/service_mariadb_database.go
+++ b/pkg/crossplane/service_mariadb_database.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -119,7 +118,7 @@ func (msb MariadbDatabaseServiceBinder) Unbind(ctx context.Context, bindingID st
 
 	cmp := composite.New(composite.WithGroupVersionKind(mariaDBUserGroupVersionKind))
 	cmp.SetName(bindingID)
-	return msb.cp.client.Delete(ctx, cmp, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	return msb.cp.client.Delete(ctx, cmp)
 }
 
 func (msb MariadbDatabaseServiceBinder) markCredentialsForDeletion(ctx context.Context, bindingID string) error {

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -16,6 +16,7 @@ import (
 	integrationtest "github.com/vshn/crossplane-service-broker/pkg/integration/test/integration"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -253,7 +254,9 @@ func RemoveObjects(ctx context.Context, objs []client.Object) PrePostRunFunc {
 	return func(c client.Client) error {
 		for _, obj := range objs {
 			if err := c.Delete(ctx, obj); err != nil {
-				return err
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION

## Summary

We were deleting the users with `foreground` cascading. Foreground cascading ensures that an owner is deleted LAST.

However, we want the owner `User` object to be deleted FIRST. So the `foreground` deletion cascade is actually the wrong way around.

By using the default `background` cascade, it will delete the owner first and only after it's gone, the owned objects.

Refs:
- https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#use-foreground-cascading-deletion
- https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`,
  as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
